### PR TITLE
feat: add model selection for sessions (Claude Max support)

### DIFF
--- a/.claude/DESIGN_STATE.yaml
+++ b/.claude/DESIGN_STATE.yaml
@@ -41,6 +41,23 @@ initialization:
       git_remote: null             # User's git remote URL (OPTIONAL - can be null/skip)
       preferred_stack: null        # User's tech stack preference or "recommend"
 
+  # Model preferences for each session (Claude Max users can use Opus for all)
+  model_preferences:
+    description: "Configure which Claude model to use for each session"
+    a_session: "opus"              # opus (default) - Architect needs deep reasoning
+    b_session: "sonnet"            # sonnet (default) | opus - Implementer
+    c_session: "sonnet"            # sonnet (default) | opus - Reviewer
+    available_models:
+      opus:
+        name: "Claude Opus 4.5"
+        description: "Best for complex reasoning, architecture, nuanced decisions"
+        recommended_for: "A Session (Architect)"
+      sonnet:
+        name: "Claude Sonnet 4.5"
+        description: "Fast, efficient, great for implementation and review"
+        recommended_for: "B/C Sessions (Implementer/Reviewer)"
+    note: "Claude Max subscribers can use Opus for all sessions for maximum capability"
+
   # Git initialization steps (local-first, remote optional)
   git_setup:
     cleared_template_git: false    # Template's .git folder removed

--- a/.claude/prompts/A_SESSION.md
+++ b/.claude/prompts/A_SESSION.md
@@ -1,4 +1,6 @@
-# A SESSION - Design and Decision (Claude Opus 4.5)
+# A SESSION - Design and Decision (Claude Opus 4.5*)
+
+*\*Model configured in `initialization.model_preferences.a_session`*
 
 ## Your Role
 
@@ -83,6 +85,12 @@ Ask these questions to configure the project:
 ║      • Or "skip" - we'll use local git only                      ║
 ║      💡 You can add a remote later when you're ready             ║
 ║                                                                  ║
+║  Q6: Which Claude model for each session? (OPTIONAL)             ║
+║      • "default" - A=Opus, B=Sonnet, C=Sonnet (cost-effective)   ║
+║      • "all-opus" - Use Opus 4.5 for all (Claude Max users)      ║
+║      • Or specify - e.g., "A=opus, B=opus, C=sonnet"             ║
+║      💡 Claude Max users can use Opus for all sessions           ║
+║                                                                  ║
 ╚══════════════════════════════════════════════════════════════════╝
 ```
 
@@ -157,6 +165,15 @@ initialization:
       use_cowork: <true/false>
       git_remote: "<answer or null>"  # null if skipped
       preferred_stack: "<answer>"
+
+  # Model preferences based on user choice (Q6)
+  model_preferences:
+    a_session: "opus"           # Always opus for architect
+    b_session: "<opus/sonnet>"  # Based on user choice
+    c_session: "<opus/sonnet>"  # Based on user choice
+    # "default" → b_session: sonnet, c_session: sonnet
+    # "all-opus" → b_session: opus, c_session: opus
+
   git_setup:
     cleared_template_git: true
     created_gitignore: true

--- a/.claude/prompts/B_SESSION.md
+++ b/.claude/prompts/B_SESSION.md
@@ -1,4 +1,6 @@
-# B SESSION - Implementation (Claude Sonnet 4.5)
+# B SESSION - Implementation (Claude Sonnet 4.5*)
+
+*\*Model configured in `initialization.model_preferences.b_session` - can be Opus 4.5 for Claude Max users*
 
 ## Your Role
 

--- a/.claude/prompts/C_SESSION.md
+++ b/.claude/prompts/C_SESSION.md
@@ -1,4 +1,6 @@
-# C SESSION - Code Review (Claude Sonnet 4.5)
+# C SESSION - Code Review (Claude Sonnet 4.5*)
+
+*\*Model configured in `initialization.model_preferences.c_session` - can be Opus 4.5 for Claude Max users*
 
 ## Your Role
 

--- a/.claude/templates/project_init.md
+++ b/.claude/templates/project_init.md
@@ -108,6 +108,12 @@ Ask these questions to understand user's intent:
 ║      • Or "skip" - we'll use local git only (recommended start)  ║
 ║      💡 You can add a remote later when you're ready to share    ║
 ║                                                                  ║
+║  Q6: Which Claude model for each session? (OPTIONAL)             ║
+║      • "default" - A=Opus, B=Sonnet, C=Sonnet (cost-effective)   ║
+║      • "all-opus" - Use Opus 4.5 for all (Claude Max users)      ║
+║      • Or customize - e.g., "A=opus, B=opus, C=sonnet"           ║
+║      💡 Claude Max subscribers can use Opus for all sessions     ║
+║                                                                  ║
 ╚══════════════════════════════════════════════════════════════════╝
 ```
 
@@ -126,6 +132,12 @@ initialization:
       use_cowork: true
       git_remote: "github.com/user/task-tracker"
       preferred_stack: "recommend"
+
+  # Model preferences (based on user choice)
+  model_preferences:
+    a_session: "opus"     # Always opus for architect
+    b_session: "opus"     # User chose "all-opus"
+    c_session: "opus"     # User chose "all-opus"
 
 meta:
   project_name: "task-tracker"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,9 @@ initialization:
 3. **Project Type**: web-app | mobile-app | api-service | full-stack | other
 4. **Tech Stack**: Your preference or "recommend" for suggestions
 5. **Git Remote** (OPTIONAL): Your repository URL or "skip" for local-only git
+6. **Model Selection** (OPTIONAL): Which Claude model for each session?
+   - Default: A=Opus, B=Sonnet, C=Sonnet (cost-effective)
+   - All Opus: Use Opus 4.5 for all sessions (Claude Max users)
 
 **Also ask about Cowork** (if macOS/Claude Desktop detected):
 - Would you like to enable Claude Cowork integration?
@@ -104,11 +107,29 @@ openspec/                 # Spec-driven development
 
 This template uses a three-session model for AI-assisted development:
 
-| Session | Model | Role | Responsibilities |
-|---------|-------|------|------------------|
+| Session | Default Model | Role | Responsibilities |
+|---------|---------------|------|------------------|
 | **A Session** | Opus 4.5 | Architect | Design, discovery, task decomposition |
-| **B Session** | Sonnet 4.5 | Implementer | Fill TODOs, self-test, create PRs |
-| **C Session** | Sonnet 4.5 | Reviewer | Code review, constraint validation |
+| **B Session** | Sonnet 4.5* | Implementer | Fill TODOs, self-test, create PRs |
+| **C Session** | Sonnet 4.5* | Reviewer | Code review, constraint validation |
+
+*\*Model configurable - Claude Max users can use Opus 4.5 for all sessions*
+
+### Model Selection
+
+During initialization, you can choose which model to use for each session:
+
+- **Default (Recommended)**: A=Opus, B=Sonnet, C=Sonnet
+  - Cost-effective balance of capability and speed
+  - Opus handles complex architecture decisions
+  - Sonnet efficiently handles implementation and review
+
+- **All Opus**: Use Opus 4.5 for all sessions
+  - Maximum capability for complex projects
+  - Best for Claude Max subscribers
+  - Ideal when implementation requires deep reasoning
+
+Model preferences are stored in `initialization.model_preferences` in DESIGN_STATE.yaml.
 
 ### Workflow Phases
 


### PR DESCRIPTION
Allow users to choose which Claude model to use for each session:
- A Session: Always Opus 4.5 (architect)
- B Session: Sonnet 4.5 (default) or Opus 4.5 (Claude Max)
- C Session: Sonnet 4.5 (default) or Opus 4.5 (Claude Max)

Changes:
- Add model_preferences section to DESIGN_STATE.yaml
- Add Q6 (model selection) to onboarding flow
- Update session prompts to reference configured model
- Document model selection options in CLAUDE.md

Claude Max subscribers can now use Opus 4.5 for all sessions for maximum capability on complex projects.